### PR TITLE
Make task decorator return Any

### DIFF
--- a/taskhawk/task_manager.py
+++ b/taskhawk/task_manager.py
@@ -12,7 +12,7 @@ from taskhawk.publisher import publish
 _ALL_TASKS: dict = {}
 
 
-def task(*args, priority: Priority = Priority.default, name: typing.Optional[str] = None) -> typing.Callable:
+def task(*args, priority: Priority = Priority.default, name: typing.Optional[str] = None) -> typing.Any:
     """
     Decorator for taskhawk task functions. Any function may be converted into a task by adding this decorator
     as such:


### PR DESCRIPTION
This PR changes the return type of the `task` decorator from `typing.Callable` to `typing.Any`.

**Why do this?**

The current annotation produces typing errors following basic usage patterns as shown in `example.py`:
```
from taskhawk import task, Priority

@task(priority=Priority.high)
def hello(name: str):
    print(f"Hello, {name}")

reveal_type(hello)
hello.dispatch("Socrates")

@task
def goodbye(name: str):
    print(f"Goodbye, {name}")

reveal_type(goodbye)
goodbye.dispatch("Socrates")
```

Before applying this PR, `mypy example.py` outputs the following:
```
example.py:7: note: Revealed type is "Any"
example.py:14: note: Revealed type is "def (*Any, **Any) -> Any"
example.py:15: error: "Callable[..., Any]" has no attribute "dispatch"
Found 1 error in 1 file (checked 1 source file)
```

Two things are notable here.

Most importantly, mypy does not allow us to dispatch the `goodbye` task.

Secondly, although we can get around this by supplying an optional argument such as `priority` (as in the `hello` task), we lose all type information in this case, which suggests that there would be no disadvantage to simply returning `Any` to begin with.

After the changes in this PR are applied, `mypy example.py` outputs the following instead:
```
➜  taskhawk-python git:(task-decorator-return-any) ✗ mypy example.py
example.py:7: note: Revealed type is "Any"
example.py:14: note: Revealed type is "Any"
```

**Why not write a more precise and accurate type annotation instead?**

This is presently impossible, as the actual return type differs depending on whether optional arguments are used (as demonstrated by the `Revealed type`s in the example.