### PR TITLE
Include task name when raising TaskNotFound

### DIFF
--- a/taskhawk/task_manager.py
+++ b/taskhawk/task_manager.py
@@ -232,4 +232,4 @@ class Task:
         """
         if name in _ALL_TASKS:
             return _ALL_TASKS[name]
-        raise TaskNotFound
+        raise TaskNotFound(name)


### PR DESCRIPTION
`TaskNotFound` may appear in logs without indicating which task could not be found.

By comparison, consider that the code `{}["foo"]` raises `KeyError("foo")` -- i.e. including the failed key in the exception raised has precedent in Python's built-in `dict` type.

This PR adds the name to the exception in line with said precedent.