### PR TITLE
Add consumer error count change hook

### DIFF
--- a/taskhawk/backends/base.py
+++ b/taskhawk/backends/base.py
@@ -74,6 +74,9 @@ class TaskhawkPublisherBaseBackend(TaskhawkBaseBackend):
 
 
 class TaskhawkConsumerBaseBackend(TaskhawkBaseBackend):
+    def error_count_change_hook_kwargs(self) -> dict:
+        return {"error_count": self.error_count}
+
     @staticmethod
     def pre_process_hook_kwargs(queue_message) -> dict:
         return {}

--- a/taskhawk/conf/__init__.py
+++ b/taskhawk/conf/__init__.py
@@ -37,6 +37,7 @@ _DEFAULTS = {
     'IS_LAMBDA_APP': False,
     'TASKHAWK_CONSUMER_BACKEND': None,
     'TASKHAWK_DEFAULT_HEADERS': 'taskhawk.conf.default_headers_hook',
+    'TASKHAWK_ERROR_COUNT_CHANGE_HOOK': 'taskhawk.conf.noop_hook',
     'TASKHAWK_PRE_PROCESS_HOOK': 'taskhawk.conf.noop_hook',
     'TASKHAWK_POST_PROCESS_HOOK': 'taskhawk.conf.noop_hook',
     'TASKHAWK_PUBLISHER_BACKEND': None,
@@ -50,6 +51,7 @@ _DEFAULTS = {
 # List of settings that may be in string import notation.
 _IMPORT_STRINGS = (
     'TASKHAWK_DEFAULT_HEADERS',
+    'TASKHAWK_ERROR_COUNT_CHANGE_HOOK',
     'TASKHAWK_PRE_PROCESS_HOOK',
     'TASKHAWK_POST_PROCESS_HOOK',
     'TASKHAWK_TASK_CLASS',

--- a/tests/test_backends/test_gcp.py
+++ b/tests/test_backends/test_gcp.py
@@ -85,6 +85,7 @@ class TestPubSubPublisher:
 
 pre_process_hook = mock.MagicMock()
 post_process_hook = mock.MagicMock()
+error_count_change_hook = mock.MagicMock()
 
 
 @pytest.fixture(name='reset_mocks')
@@ -249,6 +250,9 @@ class TestGCPConsumer:
         post_process_hook.assert_called_once_with(google_pubsub_message=queue_message)
 
     def test_error_count_increments(self, mock_pubsub_v1, gcp_settings, gcp_consumer):
+        settings.clear_cache()
+        gcp_settings.TASKHAWK_ERROR_COUNT_CHANGE_HOOK = 'tests.test_backends.test_gcp.error_count_change_hook'
+        error_count_change_hook.reset_mock()
         assert gcp_consumer.error_count == 0
 
         gcp_consumer.subscriber.pull.side_effect = ServiceUnavailable("Service Unavailable")
@@ -273,8 +277,14 @@ class TestGCPConsumer:
                 for _ in range(3)
             ]
         )
+        error_count_change_hook.assert_has_calls(
+            [mock.call(error_count=1), mock.call(error_count=2), mock.call(error_count=3)]
+        )
 
     def test_error_count_resets(self, mock_pubsub_v1, gcp_settings, gcp_consumer):
+        settings.clear_cache()
+        gcp_settings.TASKHAWK_ERROR_COUNT_CHANGE_HOOK = 'tests.test_backends.test_gcp.error_count_change_hook'
+        error_count_change_hook.reset_mock()
         gcp_consumer.subscriber.pull.side_effect = ServiceUnavailable("Service Unavailable")
 
         gcp_consumer.pull_messages(num_messages=1)
@@ -298,4 +308,7 @@ class TestGCPConsumer:
                 )
                 for _ in range(3)
             ]
+        )
+        error_count_change_hook.assert_has_calls(
+            [mock.call(error_count=1), mock.call(error_count=2), mock.call(error_count=0)]
         )


### PR DESCRIPTION
Add consumer error count change hook. Hook can be used to register a method, which publish consumer current error count state to an external monitoring service.