### PR TITLE
Add heartbeat event hook

### DIFF
--- a/taskhawk/backends/base.py
+++ b/taskhawk/backends/base.py
@@ -74,6 +74,9 @@ class TaskhawkPublisherBaseBackend(TaskhawkBaseBackend):
 
 
 class TaskhawkConsumerBaseBackend(TaskhawkBaseBackend):
+    def heartbeat_hook_kwargs(self) -> dict:
+        return {}
+
     @staticmethod
     def pre_process_hook_kwargs(queue_message) -> dict:
         return {}

--- a/taskhawk/conf/__init__.py
+++ b/taskhawk/conf/__init__.py
@@ -37,6 +37,7 @@ _DEFAULTS = {
     'IS_LAMBDA_APP': False,
     'TASKHAWK_CONSUMER_BACKEND': None,
     'TASKHAWK_DEFAULT_HEADERS': 'taskhawk.conf.default_headers_hook',
+    'TASKHAWK_HEARTBEAT_HOOK': 'taskhawk.conf.noop_hook',
     'TASKHAWK_PRE_PROCESS_HOOK': 'taskhawk.conf.noop_hook',
     'TASKHAWK_POST_PROCESS_HOOK': 'taskhawk.conf.noop_hook',
     'TASKHAWK_PUBLISHER_BACKEND': None,
@@ -50,6 +51,7 @@ _DEFAULTS = {
 # List of settings that may be in string import notation.
 _IMPORT_STRINGS = (
     'TASKHAWK_DEFAULT_HEADERS',
+    'TASKHAWK_HEARTBEAT_HOOK',
     'TASKHAWK_PRE_PROCESS_HOOK',
     'TASKHAWK_POST_PROCESS_HOOK',
     'TASKHAWK_TASK_CLASS',


### PR DESCRIPTION
Add heartbeat event hook. Hook can be used to register a method, which publish consumer current error count state to an external monitoring service.